### PR TITLE
add support for s3 transfer manager

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -165,6 +165,33 @@ on large files or objects with lots of files. Additionally, it does
 not cache any object files locally, requiring them to be retrieved
 from S3 on every access.
 
+### S3 Transfer Manager
+
+`ocfl-java` uses the new [S3 Transfer
+Manager](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/transfer-manager.html)
+to upload and download files from S3. You can configure the transfer
+manager to target a specific throughput, based on the needs of your
+application. Consult the official documentation for details.
+
+However, note that it is **crucial** that you configure the transfer
+manager to use the new [CRT S3
+client](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/crt-based-s3-client.html).
+The CRT client is **required** by the transfer manager in order to
+make multipart uploads.
+
+If you do not specify a transfer manager when constructing the
+`OcflS3Client`, then it will create the default transfer manager using
+the S3 client it was provided, which, again, should be a CRT client.
+When you use the default transfer manager, you need to be sure to
+close the `OcflRepository` when you are done with it, otherwise the
+transfer manager will not be closed.
+
+For example, you might construct the S3 client like:
+
+``` java
+S3AsyncClient.crtBuilder().build()
+```
+
 ### Configuration
 
 Use `OcflStorageBuilder.builder()` to create and configure an

--- a/ocfl-java-aws/pom.xml
+++ b/ocfl-java-aws/pom.xml
@@ -67,6 +67,14 @@
             <artifactId>s3</artifactId>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3-transfer-manager</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk.crt</groupId>
+            <artifactId>aws-crt</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.codehaus.woodstox</groupId>
             <artifactId>stax2-api</artifactId>
             <version>4.2.1</version>

--- a/ocfl-java-aws/src/main/java/edu/wisc/library/ocfl/aws/OcflS3Client.java
+++ b/ocfl-java-aws/src/main/java/edu/wisc/library/ocfl/aws/OcflS3Client.java
@@ -60,6 +60,7 @@ import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
 
 /**
@@ -244,7 +245,7 @@ public class OcflS3Client implements CloudClient {
             copy.completionFuture().join();
         } catch (RuntimeException e) {
             var cause = unwrapCompletionEx(e);
-            if (cause instanceof NoSuchKeyException) {
+            if (wasNotFound(cause)) {
                 throw new KeyNotFoundException("Key " + srcKey + " not found in bucket " + bucket, cause);
             }
             throw new OcflS3Exception("Failed to copy object from " + srcKey + " to " + dstKey, cause);
@@ -270,7 +271,7 @@ public class OcflS3Client implements CloudClient {
             download.completionFuture().join();
         } catch (RuntimeException e) {
             var cause = unwrapCompletionEx(e);
-            if (cause instanceof NoSuchKeyException) {
+            if (wasNotFound(cause)) {
                 throw new KeyNotFoundException("Key " + srcKey + " not found in bucket " + bucket, cause);
             }
             throw new OcflS3Exception("Failed to download " + srcKey + " to " + dstPath, cause);
@@ -297,7 +298,7 @@ public class OcflS3Client implements CloudClient {
                     .join();
         } catch (RuntimeException e) {
             var cause = unwrapCompletionEx(e);
-            if (cause instanceof NoSuchKeyException) {
+            if (wasNotFound(cause)) {
                 throw new KeyNotFoundException("Key " + srcKey + " not found in bucket " + bucket, cause);
             }
             throw new OcflS3Exception("Failed to download " + srcKey, cause);
@@ -337,7 +338,7 @@ public class OcflS3Client implements CloudClient {
                     .setLastModified(s3Result.lastModified());
         } catch (RuntimeException e) {
             var cause = unwrapCompletionEx(e);
-            if (cause instanceof NoSuchKeyException) {
+            if (wasNotFound(cause)) {
                 throw new KeyNotFoundException("Key " + key + " not found in bucket " + bucket, cause);
             }
             throw new OcflS3Exception("Failed to HEAD " + key, cause);
@@ -479,7 +480,7 @@ public class OcflS3Client implements CloudClient {
             return true;
         } catch (RuntimeException e) {
             var cause = unwrapCompletionEx(e);
-            if (cause instanceof NoSuchBucketException) {
+            if (wasNotFound(cause)) {
                 return false;
             }
             throw new OcflS3Exception("Failed ot HEAD bucket " + bucket, cause);
@@ -557,6 +558,23 @@ public class OcflS3Client implements CloudClient {
             cause = e.getCause();
         }
         return cause;
+    }
+
+    /**
+     * Returns true if the exception indicates the object/bucket was NOT found in S3.
+     *
+     * @param e the exception
+     * @return true if the object/bucket was NOT found in S3.
+     */
+    private boolean wasNotFound(Throwable e) {
+        if (e instanceof NoSuchKeyException || e instanceof NoSuchBucketException) {
+            return true;
+        } else if (e instanceof S3Exception) {
+            // It seems like the CRT client does not return NoSuchKeyExceptions...
+            var s3e = (S3Exception) e;
+            return 404 == s3e.statusCode();
+        }
+        return false;
     }
 
     public static class Builder {

--- a/ocfl-java-aws/src/main/java/edu/wisc/library/ocfl/aws/OcflS3Client.java
+++ b/ocfl-java-aws/src/main/java/edu/wisc/library/ocfl/aws/OcflS3Client.java
@@ -24,6 +24,7 @@
 
 package edu.wisc.library.ocfl.aws;
 
+import edu.wisc.library.ocfl.api.OcflRepository;
 import edu.wisc.library.ocfl.api.exception.OcflIOException;
 import edu.wisc.library.ocfl.api.util.Enforce;
 import edu.wisc.library.ocfl.core.storage.cloud.CloudClient;
@@ -68,8 +69,6 @@ public class OcflS3Client implements CloudClient {
 
     private static final Logger LOG = LoggerFactory.getLogger(OcflS3Client.class);
 
-    // TODO TM add more notes about CRT client
-    // TODO TM notes about closing
     private final S3AsyncClient s3Client;
     private final S3TransferManager transferManager;
     private final String bucket;
@@ -569,7 +568,12 @@ public class OcflS3Client implements CloudClient {
         private BiConsumer<String, PutObjectRequest.Builder> putObjectModifier;
 
         /**
-         * The AWS SDK S3 client. This SHOULD be a CRT client. Required.
+         * The AWS SDK S3 client. Required.
+         * <p>
+         * This <b>SHOULD</b> be a {@link <a href="https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/crt-based-s3-client.html">CRT client</a>}.
+         * The reason for this is that the {@link S3TransferManager} requires the CRT client for doing multipart uploads.
+         * <p>
+         * This client is NOT closed when the repository is closed, and the user is responsible for closing it when appropriate.
          *
          * @param s3Client s3 client
          * @return builder
@@ -583,6 +587,9 @@ public class OcflS3Client implements CloudClient {
          * The AWS SDK S3 transfer manager. This only needs to be specified when you need to set specific settings, and,
          * if it is specified, it can use the same S3 client as was supplied in {@link #s3Client(S3AsyncClient)}.
          * Otherwise, when not specified, the default transfer manager is created using the provided S3 Client.
+         * <p>
+         * When a transfer manager is provided, it will NOT be closed when the repository is closed, and the user is
+         * responsible for closing it when appropriate.
          *
          * @param transferManager S3 transfer manager
          * @return builder
@@ -630,7 +637,10 @@ public class OcflS3Client implements CloudClient {
         }
 
         /**
-         * Constructs a new OcflS3Client. s3Client and bucket must be set.
+         * Constructs a new {@link OcflS3Client}. {@link #s3Client(S3AsyncClient)} and {@link #bucket(String)} must be set.
+         * <p>
+         * Remember to call {@link OcflRepository#close()} when you are done with the repository so that the default
+         * S3 transfer manager is closed.
          *
          * @return OcflS3Client
          */

--- a/ocfl-java-aws/src/main/java/edu/wisc/library/ocfl/aws/OcflS3Client.java
+++ b/ocfl-java-aws/src/main/java/edu/wisc/library/ocfl/aws/OcflS3Client.java
@@ -570,7 +570,7 @@ public class OcflS3Client implements CloudClient {
         /**
          * The AWS SDK S3 client. Required.
          * <p>
-         * This <b>SHOULD</b> be a {@link <a href="https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/crt-based-s3-client.html">CRT client</a>}.
+         * This <b>SHOULD</b> be a <a href="https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/crt-based-s3-client.html">CRT client</a>.
          * The reason for this is that the {@link S3TransferManager} requires the CRT client for doing multipart uploads.
          * <p>
          * This client is NOT closed when the repository is closed, and the user is responsible for closing it when appropriate.

--- a/ocfl-java-aws/src/main/java/edu/wisc/library/ocfl/aws/OcflS3Exception.java
+++ b/ocfl-java-aws/src/main/java/edu/wisc/library/ocfl/aws/OcflS3Exception.java
@@ -1,0 +1,47 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 University of Wisconsin Board of Regents
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package edu.wisc.library.ocfl.aws;
+
+import edu.wisc.library.ocfl.api.exception.OcflJavaException;
+
+/**
+ * Captures an error that occurred while interacting with S3.
+ */
+public class OcflS3Exception extends OcflJavaException {
+
+    public OcflS3Exception() {}
+
+    public OcflS3Exception(String message) {
+        super(message);
+    }
+
+    public OcflS3Exception(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public OcflS3Exception(Throwable cause) {
+        super(cause.getMessage(), cause);
+    }
+}

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/OcflRepositoryBuilder.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/OcflRepositoryBuilder.java
@@ -63,7 +63,7 @@ import java.util.function.Consumer;
 
 /**
  * Constructs a local file system based OCFL repository sensible defaults that can be overridden prior to calling
- * build().
+ * {@link #build()}.
  *
  * <p>Important: The same OcflRepositoryBuilder instance MUST NOT be used to initialize multiple repositories.
  */
@@ -86,7 +86,7 @@ public class OcflRepositoryBuilder {
 
     /**
      * Constructs a local file system based OCFL repository sensible defaults that can be overridden prior to calling
-     * build().
+     * {@link #build()}.
      *
      * <p>Important: The same OcflRepositoryBuilder instance MUST NOT be used to initialize multiple repositories.
      */
@@ -375,6 +375,8 @@ public class OcflRepositoryBuilder {
 
     /**
      * Constructs an OCFL repository. Brand new repositories are initialized.
+     * <p>
+     * Remember to call {@link OcflRepository#close()} when you are done with the repository.
      *
      * @return OcflRepository
      */
@@ -384,6 +386,8 @@ public class OcflRepositoryBuilder {
 
     /**
      * Constructs an OCFL repository that allows the use of the Mutable HEAD Extension. Brand new repositories are initialized.
+     * <p>
+     * Remember to call {@link OcflRepository#close()} when you are done with the repository.
      *
      * @return MutableOcflRepository
      */

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/storage/DefaultOcflStorage.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/storage/DefaultOcflStorage.java
@@ -618,6 +618,7 @@ public class DefaultOcflStorage extends AbstractOcflStorage {
     public void close() {
         LOG.debug("Closing {}", this.getClass().getName());
         super.close();
+        storage.close();
     }
 
     @Override

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/storage/cloud/CloudClient.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/storage/cloud/CloudClient.java
@@ -34,6 +34,11 @@ import java.util.Collection;
 public interface CloudClient {
 
     /**
+     * Close any resources the client may have created. This will NOT close resources that were passed into the client.
+     */
+    void close();
+
+    /**
      * The name of the bucket the OCFL repository is in.
      *
      * @return bucket name

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/storage/cloud/CloudStorage.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/storage/cloud/CloudStorage.java
@@ -328,6 +328,14 @@ public class CloudStorage implements Storage {
         // no-op
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close() {
+        client.close();
+    }
+
     private void failOnExistingFile(String path) {
         if (fileExists(path)) {
             throw new OcflFileAlreadyExistsException(String.format("File %s already exists", path));

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/storage/common/Storage.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/storage/common/Storage.java
@@ -188,4 +188,9 @@ public interface Storage {
      * @param path starting path
      */
     void deleteEmptyDirsUp(String path);
+
+    /**
+     * Closes any resources the storage implementation may have open.
+     */
+    void close();
 }

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/storage/filesystem/FileSystemStorage.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/storage/filesystem/FileSystemStorage.java
@@ -347,4 +347,12 @@ public class FileSystemStorage implements Storage {
         var fullPath = storageRoot.resolve(path);
         FileUtil.deleteDirAndParentsIfEmpty(fullPath);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close() {
+        // no-op
+    }
 }

--- a/ocfl-java-itest/src/test/java/edu/wisc/library/ocfl/itest/s3/S3BadReposITest.java
+++ b/ocfl-java-itest/src/test/java/edu/wisc/library/ocfl/itest/s3/S3BadReposITest.java
@@ -17,11 +17,13 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.transfer.s3.S3TransferManager;
 
 public class S3BadReposITest extends BadReposITest {
 
@@ -33,7 +35,8 @@ public class S3BadReposITest extends BadReposITest {
     @RegisterExtension
     public static S3MockExtension S3_MOCK = S3MockExtension.builder().silent().build();
 
-    private static S3Client s3Client;
+    private static S3AsyncClient s3Client;
+    private static S3TransferManager transferManager;
     private static String bucket;
 
     private static ComboPooledDataSource dataSource;
@@ -53,17 +56,26 @@ public class S3BadReposITest extends BadReposITest {
             S3BadReposITest.bucket = bucket;
         } else {
             LOG.info("Running tests against S3 Mock");
-            s3Client = S3_MOCK.createS3ClientV2();
+            s3Client = S3ITestHelper.createMockS3Client(S3_MOCK.getServiceEndpoint());
             S3BadReposITest.bucket = UUID.randomUUID().toString();
             s3Client.createBucket(request -> {
-                request.bucket(S3BadReposITest.bucket);
-            });
+                        request.bucket(S3BadReposITest.bucket);
+                    })
+                    .join();
         }
+
+        transferManager = S3TransferManager.builder().s3Client(s3Client).build();
 
         dataSource = new ComboPooledDataSource();
         dataSource.setJdbcUrl(System.getProperty("db.url", "jdbc:h2:mem:test"));
         dataSource.setUser(System.getProperty("db.user", ""));
         dataSource.setPassword(System.getProperty("db.password", ""));
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        s3Client.close();
+        transferManager.close();
     }
 
     @Override
@@ -119,6 +131,7 @@ public class S3BadReposITest extends BadReposITest {
 
         return OcflS3Client.builder()
                 .s3Client(s3Client)
+                .transferManager(transferManager)
                 .bucket(bucket)
                 .repoPrefix(prefix(name))
                 .build();

--- a/ocfl-java-itest/src/test/java/edu/wisc/library/ocfl/itest/s3/S3ITestHelper.java
+++ b/ocfl-java-itest/src/test/java/edu/wisc/library/ocfl/itest/s3/S3ITestHelper.java
@@ -4,11 +4,13 @@ import static edu.wisc.library.ocfl.itest.ITestHelper.computeDigest;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static software.amazon.awssdk.http.SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES;
 
 import edu.wisc.library.ocfl.api.model.DigestAlgorithm;
 import edu.wisc.library.ocfl.core.util.DigestUtil;
 import edu.wisc.library.ocfl.core.util.FileUtil;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -16,28 +18,44 @@ import java.util.List;
 import java.util.stream.Collectors;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.S3Object;
+import software.amazon.awssdk.utils.AttributeMap;
 
 public class S3ITestHelper {
 
     private static final String OCFL_SPEC_FILE = "ocfl_1.1.md";
 
-    private S3Client s3Client;
+    private S3AsyncClient s3Client;
 
-    public S3ITestHelper(S3Client s3Client) {
+    public S3ITestHelper(S3AsyncClient s3Client) {
         this.s3Client = s3Client;
     }
 
-    public static S3Client createS3Client(String accessKey, String secretKey) {
-        return S3Client.builder()
+    public static S3AsyncClient createS3Client(String accessKey, String secretKey) {
+        return S3AsyncClient.crtBuilder()
                 .region(Region.US_EAST_2)
                 .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
-                .httpClientBuilder(ApacheHttpClient.builder())
+                .build();
+    }
+
+    public static S3AsyncClient createMockS3Client(String endpoint) {
+        return S3AsyncClient.builder()
+                .endpointOverride(URI.create(endpoint))
+                .region(Region.US_EAST_2)
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("foo", "bar")))
+                .serviceConfiguration(
+                        S3Configuration.builder().pathStyleAccessEnabled(true).build())
+                .httpClient(NettyNioAsyncHttpClient.builder()
+                        .buildWithDefaults(AttributeMap.builder()
+                                .put(TRUST_ALL_CERTIFICATES, Boolean.TRUE)
+                                .build()))
                 .build();
     }
 
@@ -80,14 +98,14 @@ public class S3ITestHelper {
     }
 
     private byte[] getObjectContent(String bucket, String prefix, String key) {
-        try (var result = s3Client.getObject(GetObjectRequest.builder()
-                .bucket(bucket)
-                .key(prefix + "/" + key)
-                .build())) {
-            return result.readAllBytes();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        return s3Client.getObject(
+                        GetObjectRequest.builder()
+                                .bucket(bucket)
+                                .key(prefix + "/" + key)
+                                .build(),
+                        AsyncResponseTransformer.toBytes())
+                .join()
+                .asByteArray();
     }
 
     private String computeS3Digest(String bucket, String prefix, String key) {
@@ -95,8 +113,11 @@ public class S3ITestHelper {
     }
 
     public List<String> listAllObjects(String bucket, String prefix) {
-        var result = s3Client.listObjectsV2(
-                ListObjectsV2Request.builder().bucket(bucket).prefix(prefix).build());
+        var result = s3Client.listObjectsV2(ListObjectsV2Request.builder()
+                        .bucket(bucket)
+                        .prefix(prefix)
+                        .build())
+                .join();
 
         return result.contents().stream()
                 .map(S3Object::key)

--- a/ocfl-java-itest/src/test/java/edu/wisc/library/ocfl/itest/s3/S3MutableHeadITest.java
+++ b/ocfl-java-itest/src/test/java/edu/wisc/library/ocfl/itest/s3/S3MutableHeadITest.java
@@ -23,11 +23,13 @@ import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Consumer;
 import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.transfer.s3.S3TransferManager;
 
 public class S3MutableHeadITest extends MutableHeadITest {
 
@@ -39,7 +41,8 @@ public class S3MutableHeadITest extends MutableHeadITest {
     @RegisterExtension
     public static S3MockExtension S3_MOCK = S3MockExtension.builder().silent().build();
 
-    private static S3Client s3Client;
+    private static S3AsyncClient s3Client;
+    private static S3TransferManager transferManager;
     private static String bucket;
 
     private static ComboPooledDataSource dataSource;
@@ -59,17 +62,26 @@ public class S3MutableHeadITest extends MutableHeadITest {
             S3MutableHeadITest.bucket = bucket;
         } else {
             LOG.info("Running tests against S3 Mock");
-            s3Client = S3_MOCK.createS3ClientV2();
+            s3Client = S3ITestHelper.createMockS3Client(S3_MOCK.getServiceEndpoint());
             S3MutableHeadITest.bucket = UUID.randomUUID().toString();
             s3Client.createBucket(request -> {
-                request.bucket(S3MutableHeadITest.bucket);
-            });
+                        request.bucket(S3MutableHeadITest.bucket);
+                    })
+                    .join();
         }
+
+        transferManager = S3TransferManager.builder().s3Client(s3Client).build();
 
         dataSource = new ComboPooledDataSource();
         dataSource.setJdbcUrl(System.getProperty("db.url", "jdbc:h2:mem:test"));
         dataSource.setUser(System.getProperty("db.user", ""));
         dataSource.setPassword(System.getProperty("db.password", ""));
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        s3Client.close();
+        transferManager.close();
     }
 
     @Override
@@ -145,6 +157,7 @@ public class S3MutableHeadITest extends MutableHeadITest {
 
         return OcflS3Client.builder()
                 .s3Client(s3Client)
+                .transferManager(transferManager)
                 .bucket(bucket)
                 .repoPrefix(prefix(name))
                 .build();

--- a/ocfl-java-itest/src/test/java/edu/wisc/library/ocfl/itest/s3/S3OcflITest.java
+++ b/ocfl-java-itest/src/test/java/edu/wisc/library/ocfl/itest/s3/S3OcflITest.java
@@ -34,13 +34,15 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.transfer.s3.S3TransferManager;
 
 public class S3OcflITest extends OcflITest {
 
@@ -56,7 +58,8 @@ public class S3OcflITest extends OcflITest {
     @RegisterExtension
     public static S3MockExtension S3_MOCK = S3MockExtension.builder().silent().build();
 
-    private static S3Client s3Client;
+    private static S3AsyncClient s3Client;
+    private static S3TransferManager transferManager;
     private static String bucket;
 
     private static ComboPooledDataSource dataSource;
@@ -76,17 +79,26 @@ public class S3OcflITest extends OcflITest {
             S3OcflITest.bucket = bucket;
         } else {
             LOG.info("Running tests against S3 Mock");
-            s3Client = S3_MOCK.createS3ClientV2();
+            s3Client = S3ITestHelper.createMockS3Client(S3_MOCK.getServiceEndpoint());
             S3OcflITest.bucket = UUID.randomUUID().toString();
             s3Client.createBucket(request -> {
-                request.bucket(S3OcflITest.bucket);
-            });
+                        request.bucket(S3OcflITest.bucket);
+                    })
+                    .join();
         }
+
+        transferManager = S3TransferManager.builder().s3Client(s3Client).build();
 
         dataSource = new ComboPooledDataSource();
         dataSource.setJdbcUrl(System.getProperty("db.url", "jdbc:h2:mem:test"));
         dataSource.setUser(System.getProperty("db.user", ""));
         dataSource.setPassword(System.getProperty("db.password", ""));
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        s3Client.close();
+        transferManager.close();
     }
 
     @Override
@@ -247,6 +259,7 @@ public class S3OcflITest extends OcflITest {
 
         return OcflS3Client.builder()
                 .s3Client(s3Client)
+                .transferManager(transferManager)
                 .bucket(bucket)
                 .repoPrefix(prefix(name))
                 .build();

--- a/ocfl-java-itest/src/test/java/edu/wisc/library/ocfl/itest/s3/S3StorageTest.java
+++ b/ocfl-java-itest/src/test/java/edu/wisc/library/ocfl/itest/s3/S3StorageTest.java
@@ -13,11 +13,14 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.transfer.s3.S3TransferManager;
 
 public class S3StorageTest extends StorageTest {
 
@@ -27,7 +30,8 @@ public class S3StorageTest extends StorageTest {
     @RegisterExtension
     public static S3MockExtension S3_MOCK = S3MockExtension.builder().silent().build();
 
-    private static S3Client s3Client;
+    private static S3AsyncClient s3Client;
+    private static S3TransferManager transferManager;
     private static String bucket;
 
     private Set<String> repoPrefixes = new HashSet<>();
@@ -36,11 +40,19 @@ public class S3StorageTest extends StorageTest {
 
     @BeforeAll
     public static void beforeAll() {
-        s3Client = S3_MOCK.createS3ClientV2();
+        s3Client = S3ITestHelper.createMockS3Client(S3_MOCK.getServiceEndpoint());
         S3StorageTest.bucket = UUID.randomUUID().toString();
         s3Client.createBucket(request -> {
-            request.bucket(S3StorageTest.bucket);
-        });
+                    request.bucket(S3StorageTest.bucket);
+                })
+                .join();
+        transferManager = S3TransferManager.builder().s3Client(s3Client).build();
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        s3Client.close();
+        transferManager.close();
     }
 
     @AfterEach
@@ -65,16 +77,20 @@ public class S3StorageTest extends StorageTest {
 
     protected void file(String path, String content) {
         s3Client.putObject(
-                request -> {
-                    request.bucket(bucket).key(FileUtil.pathJoinFailEmpty(prefix(name), path));
-                },
-                RequestBody.fromString(content));
+                        request -> {
+                            request.bucket(bucket).key(FileUtil.pathJoinFailEmpty(prefix(name), path));
+                        },
+                        AsyncRequestBody.fromString(content))
+                .join();
     }
 
     protected String readFile(String path) {
-        try (var content = s3Client.getObject(request -> {
-            request.bucket(bucket).key(FileUtil.pathJoinFailEmpty(prefix(name), path));
-        })) {
+        try (var content = s3Client.getObject(
+                        request -> {
+                            request.bucket(bucket).key(FileUtil.pathJoinFailEmpty(prefix(name), path));
+                        },
+                        AsyncResponseTransformer.toBlockingInputStream())
+                .join()) {
             return new String(content.readAllBytes());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -86,6 +102,7 @@ public class S3StorageTest extends StorageTest {
 
         return OcflS3Client.builder()
                 .s3Client(s3Client)
+                .transferManager(transferManager)
                 .bucket(bucket)
                 .repoPrefix(prefix(name))
                 .build();

--- a/pom.xml
+++ b/pom.xml
@@ -339,9 +339,14 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.17.290</version>
+                <version>2.19.8</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>software.amazon.awssdk.crt</groupId>
+                <artifactId>aws-crt</artifactId>
+                <version>0.20.5</version>
             </dependency>
 
             <!-- Test -->
@@ -388,7 +393,7 @@
             <dependency>
                 <groupId>com.adobe.testing</groupId>
                 <artifactId>s3mock-junit5</artifactId>
-                <version>2.8.0</version>
+                <version>2.11.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This PR adds support for the [S3 transfer manager](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/transfer-manager.html). The transfer manager requires the new [CRT client](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/crt-based-s3-client.html). The CRT client is currently an async-only client, and previously ocfl-java used the sync S3 client. This makes these changes **breaking changes**. Additionally, the CRT client does not currently support as many configuration settings as the non-CRT clients. For example, it is not possible to enable path-style access.

I still need to do some testing to get some numbers, but my expectation is that switching to the transfer manager should significantly improve ocfl-java's S3 performance. However, due to the limitations of the client, we need to thoroughly test these changes to ensure that it will work for ocfl-java's current users.

To test, you'll need to change the way you build your S3 client. You should now do something like this:

```java
OcflS3Client.builder()
        // Note the crtBuilder()
        .s3Client(S3AsyncClient.crtBuilder().build())
        .bucket("example-bucket")
        .build();
```

Or this, if you want to turn the nobs on the transfer manager:

```java
var s3Client = S3AsyncClient.crtBuilder().build();
var transferManager = S3TransferManager.builder().s3Client(s3Client).build();
        
OcflS3Client.builder()
        .s3Client(s3Client)
        .transferManager(transferManager)
        .bucket("example-bucket")
        .build();
```

Please test the new client on your systems, and report back if it works for you. Thanks!