### PR TITLE
replace `Files.walk()` with `Files.find()`

### DIFF
--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/DefaultOcflRepository.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/DefaultOcflRepository.java
@@ -658,8 +658,8 @@ public class DefaultOcflRepository implements OcflRepository {
         var expected = new HashSet<String>(fileIds.size());
         expected.addAll(fileIds);
 
-        try (var paths = Files.walk(contentPath)) {
-            paths.filter(Files::isRegularFile).forEach(file -> {
+        try (var paths = Files.find(contentPath, Integer.MAX_VALUE, (file, attrs) -> attrs.isRegularFile())) {
+            paths.forEach(file -> {
                 var fileContentPath = prefix + FileUtil.pathToStringStandardSeparator(rootPath.relativize(file));
                 var expectedDigest = inventory.getFileId(fileContentPath);
 

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/inventory/AddFileProcessor.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/inventory/AddFileProcessor.java
@@ -110,8 +110,9 @@ public class AddFileProcessor {
         var optionsSet = OcflOption.toSet(options);
         var destination = destinationPath(destinationPath, sourcePath);
 
-        try (var paths = Files.walk(sourcePath, FileVisitOption.FOLLOW_LINKS)) {
-            paths.filter(Files::isRegularFile).forEach(file -> {
+        try (var paths = Files.find(
+                sourcePath, Integer.MAX_VALUE, (file, attrs) -> attrs.isRegularFile(), FileVisitOption.FOLLOW_LINKS)) {
+            paths.forEach(file -> {
                 messageDigest.reset();
                 var logicalPath = logicalPath(sourcePath, file, destination);
 

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/storage/cloud/CloudStorage.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/storage/cloud/CloudStorage.java
@@ -241,8 +241,8 @@ public class CloudStorage implements Storage {
 
         var objectKeys = Collections.synchronizedList(new ArrayList<String>());
 
-        try (var paths = Files.walk(source)) {
-            paths.filter(Files::isRegularFile).forEach(file -> {
+        try (var paths = Files.find(source, Integer.MAX_VALUE, (file, attrs) -> attrs.isRegularFile())) {
+            paths.forEach(file -> {
                 var relative = FileUtil.pathToStringStandardSeparator(source.relativize(file));
                 var key = FileUtil.pathJoinFailEmpty(destination, relative);
                 client.uploadFile(file, key);

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/util/FileUtil.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/util/FileUtil.java
@@ -235,10 +235,8 @@ public final class FileUtil {
      * @param root the path to prune empty child directories from
      */
     public static void deleteEmptyDirs(Path root) {
-        try (var files = Files.walk(root)) {
-            files.filter(f -> Files.isDirectory(f, LinkOption.NOFOLLOW_LINKS))
-                    .filter(f -> !f.equals(root))
-                    .forEach(FileUtil::deleteDirIfEmpty);
+        try (var files = Files.find(root, Integer.MAX_VALUE, (file, attrs) -> attrs.isDirectory())) {
+            files.filter(f -> !f.equals(root)).forEach(FileUtil::deleteDirIfEmpty);
         } catch (NoSuchFileException e) {
             // ignore
         } catch (IOException e) {
@@ -374,8 +372,8 @@ public final class FileUtil {
         var files = new ArrayList<Path>();
 
         if (Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)) {
-            try (var paths = Files.walk(path)) {
-                paths.filter(Files::isRegularFile).forEach(files::add);
+            try (var paths = Files.find(path, Integer.MAX_VALUE, (file, attrs) -> attrs.isRegularFile())) {
+                paths.forEach(files::add);
             } catch (IOException e) {
                 throw OcflIOException.from(e);
             }


### PR DESCRIPTION
This reduces the number of system calls when filtering on a specific file type.