### PR TITLE
Revert "make all file operations synchronous"

### DIFF
--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/DefaultOcflRepository.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/DefaultOcflRepository.java
@@ -64,6 +64,7 @@ import edu.wisc.library.ocfl.core.util.ResponseMapper;
 import edu.wisc.library.ocfl.core.util.UncheckedFiles;
 import edu.wisc.library.ocfl.core.validation.InventoryValidator;
 import edu.wisc.library.ocfl.core.validation.Validator;
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
@@ -688,7 +689,7 @@ public class DefaultOcflRepository implements OcflRepository {
     protected Inventory writeInventory(Inventory inventory, Path stagingDir) {
         var inventoryPath = ObjectPaths.inventoryPath(stagingDir);
 
-        try (var outStream = FileUtil.newBufferedOutputStream(inventoryPath)) {
+        try (var outStream = new BufferedOutputStream(Files.newOutputStream(inventoryPath))) {
             var digestStream = new DigestOutputStream(
                     outStream, inventory.getDigestAlgorithm().getMessageDigest());
             inventoryMapper.write(digestStream, inventory);

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/inventory/AddFileProcessor.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/inventory/AddFileProcessor.java
@@ -32,12 +32,14 @@ import edu.wisc.library.ocfl.api.util.Enforce;
 import edu.wisc.library.ocfl.core.util.DigestUtil;
 import edu.wisc.library.ocfl.core.util.FileUtil;
 import edu.wisc.library.ocfl.core.util.UncheckedFiles;
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.util.HashMap;
@@ -138,8 +140,13 @@ public class AddFileProcessor {
                     String digest;
                     InventoryUpdater.AddFileResult result;
 
-                    try (var stream =
-                            new DigestOutputStream(FileUtil.newBufferedOutputStream(stagingFullPath), messageDigest)) {
+                    try (var stream = new DigestOutputStream(
+                            new BufferedOutputStream(Files.newOutputStream(
+                                    stagingFullPath,
+                                    StandardOpenOption.CREATE,
+                                    StandardOpenOption.WRITE,
+                                    StandardOpenOption.TRUNCATE_EXISTING)),
+                            messageDigest)) {
                         LOG.debug("Copying file <{}> to <{}>", file, stagingFullPath);
                         Files.copy(file, stream);
 

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/inventory/SidecarMapper.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/inventory/SidecarMapper.java
@@ -32,7 +32,6 @@ import edu.wisc.library.ocfl.api.exception.OcflNoSuchFileException;
 import edu.wisc.library.ocfl.api.model.DigestAlgorithm;
 import edu.wisc.library.ocfl.core.ObjectPaths;
 import edu.wisc.library.ocfl.core.model.Inventory;
-import edu.wisc.library.ocfl.core.util.FileUtil;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -49,7 +48,7 @@ public final class SidecarMapper {
     public static void writeSidecar(Inventory inventory, String digest, Path dstDirectory) {
         try {
             var sidecarPath = ObjectPaths.inventorySidecarPath(dstDirectory, inventory);
-            FileUtil.writeString(sidecarPath, String.format("%s  %s\n", digest, OcflConstants.INVENTORY_FILE));
+            Files.writeString(sidecarPath, String.format("%s  %s\n", digest, OcflConstants.INVENTORY_FILE));
         } catch (IOException e) {
             throw new OcflIOException(e);
         }

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/storage/filesystem/FileSystemStorage.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/storage/filesystem/FileSystemStorage.java
@@ -201,12 +201,7 @@ public class FileSystemStorage implements Storage {
         var fullPath = storageRoot.resolve(filePath);
 
         try {
-            Files.write(
-                    fullPath,
-                    content,
-                    StandardOpenOption.WRITE,
-                    StandardOpenOption.CREATE_NEW,
-                    StandardOpenOption.SYNC);
+            Files.write(fullPath, content, StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW);
         } catch (IOException e) {
             throw OcflIOException.from(e);
         }

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/util/FileUtil.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/util/FileUtil.java
@@ -29,10 +29,8 @@ import edu.wisc.library.ocfl.api.exception.OcflIOException;
 import edu.wisc.library.ocfl.api.exception.OcflNoSuchFileException;
 import edu.wisc.library.ocfl.api.model.DigestAlgorithm;
 import edu.wisc.library.ocfl.api.util.Enforce;
-import java.io.BufferedOutputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.FileAlreadyExistsException;
@@ -41,11 +39,9 @@ import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.NoSuchFileException;
-import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
-import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -62,16 +58,6 @@ public final class FileUtil {
     private FileUtil() {}
 
     private static final Logger LOG = LoggerFactory.getLogger(FileUtil.class);
-
-    /**
-     * These are the default JDK open options when none are specified PLUS sync.
-     */
-    private static final OpenOption[] STANDARD_OPEN_OPTIONS = {
-        StandardOpenOption.CREATE,
-        StandardOpenOption.TRUNCATE_EXISTING,
-        StandardOpenOption.WRITE,
-        StandardOpenOption.SYNC
-    };
 
     /**
      * Creates a new directory as a child of the parent path named: md5(objectId)-[random-long]
@@ -382,36 +368,6 @@ public final class FileUtil {
         }
 
         return files;
-    }
-
-    /**
-     * Creates a new buffered output stream. Use this instead of {@link Files#newOutputStream(Path, OpenOption...)}
-     * because it wil a) buffer the stream, and b) make it sync.
-     * <p>
-     * This uses the options create, truncate_existing, write, and sync. If you don't want these options. Use
-     * {@link Files} directly.
-     *
-     * @param path the path to the file to open
-     * @return the buffered output stream
-     * @throws IOException
-     */
-    public static OutputStream newBufferedOutputStream(Path path) throws IOException {
-        return new BufferedOutputStream(Files.newOutputStream(path, STANDARD_OPEN_OPTIONS));
-    }
-
-    /**
-     * Writes a string to a file.
-     * <p>
-     * This uses the options create, truncate_existing, write, and sync. If you don't want these options. Use
-     * {@link Files} directly.
-     *
-     * @param path the path to the file to write
-     * @param value the value to write to the file
-     * @return the path to the file
-     * @throws IOException
-     */
-    public static Path writeString(Path path, String value) throws IOException {
-        return Files.writeString(path, value, STANDARD_OPEN_OPTIONS);
     }
 
     public static StandardCopyOption[] toCopyOptions(OcflOption... options) {

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/util/NamasteTypeFile.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/util/NamasteTypeFile.java
@@ -27,6 +27,7 @@ package edu.wisc.library.ocfl.core.util;
 import edu.wisc.library.ocfl.api.exception.OcflIOException;
 import edu.wisc.library.ocfl.api.util.Enforce;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 public class NamasteTypeFile {
@@ -49,7 +50,7 @@ public class NamasteTypeFile {
 
     public void writeFile(Path directory) {
         try {
-            FileUtil.writeString(directory.resolve(fileName()), fileContent());
+            Files.writeString(directory.resolve(fileName()), fileContent());
         } catch (IOException e) {
             throw OcflIOException.from(e);
         }


### PR DESCRIPTION
This reverts commit 39c09e22cd946b618764ad623d3c3d63598565d6.

I'm reverting the change that made some of the write operations synchronous for now, because it turns out copies have the same problem and the standard library does not expose an option for making them synchronous. Additionally, it was reported that making the writes synchronous had a significant performance impact. So, if we decide to add synchronous writes, they must be opt-in, and they must be applied to all operations, including those that the standard library does not offer an easy way to make synchronous.