### PR TITLE
use different client for transfer manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 - **Breaking:** A `S3AsyncClient` S3 client now must be used with ocfl-java-aws, and the sync version is no longer supported.
 - ocfl-java-aws now uses the [S3 Transfer Manager](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/transfer-manager.html)
-  to upload and download files from S3. See the [usage guide](docs/USAGE.md#s3-transfer-manager) for more details.
+  to upload files to S3. See the [usage guide](docs/USAGE.md#s3-transfer-manager) for more details.
 - ocfl-java-aws now concurrently uploads files when writing an object to S3. This should improve object write performance.
 - The `OcflObjectUpdater` was updated to be thread safe, enabling concurrently writing files to it. This _may_ speed up
   writing a large number of files to an object. See the [usage guide](docs/USAGE.md#improving-write-performance) for

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@ build:
     ./mvnw -DskipTests clean package
 
 # Installs ocfl-java into local M2
-install: build
+install:
     ./mvnw -DskipTests clean install
 
 # Runs the tests

--- a/ocfl-java-aws/pom.xml
+++ b/ocfl-java-aws/pom.xml
@@ -67,6 +67,10 @@
             <artifactId>s3</artifactId>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk.crt</groupId>
+            <artifactId>aws-crt</artifactId>
+        </dependency>
+        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3-transfer-manager</artifactId>
         </dependency>
@@ -90,11 +94,6 @@
         </dependency>
 
         <!-- Test -->
-        <dependency>
-            <groupId>software.amazon.awssdk.crt</groupId>
-            <artifactId>aws-crt</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/ocfl-java-aws/src/main/java/io/ocfl/aws/UploadFuture.java
+++ b/ocfl-java-aws/src/main/java/io/ocfl/aws/UploadFuture.java
@@ -26,22 +26,22 @@ package io.ocfl.aws;
 
 import io.ocfl.core.storage.cloud.CloudObjectKey;
 import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import software.amazon.awssdk.transfer.s3.model.FileUpload;
 
 /**
  * Converts a FileUpload CompletionFuture into a regular Future.
  */
 public class UploadFuture implements Future<CloudObjectKey> {
 
-    private final FileUpload upload;
+    private final CompletableFuture<?> upload;
     private final Path srcPath;
     private final CloudObjectKey dstKey;
 
-    public UploadFuture(FileUpload upload, Path srcPath, CloudObjectKey dstKey) {
+    public UploadFuture(CompletableFuture<?> upload, Path srcPath, CloudObjectKey dstKey) {
         this.upload = upload;
         this.srcPath = srcPath;
         this.dstKey = dstKey;
@@ -49,23 +49,23 @@ public class UploadFuture implements Future<CloudObjectKey> {
 
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
-        return upload.completionFuture().cancel(mayInterruptIfRunning);
+        return upload.cancel(mayInterruptIfRunning);
     }
 
     @Override
     public boolean isCancelled() {
-        return upload.completionFuture().isCancelled();
+        return upload.isCancelled();
     }
 
     @Override
     public boolean isDone() {
-        return upload.completionFuture().isDone();
+        return upload.isDone();
     }
 
     @Override
     public CloudObjectKey get() throws InterruptedException, ExecutionException {
         try {
-            upload.completionFuture().get();
+            upload.get();
         } catch (RuntimeException e) {
             throw new ExecutionException(new OcflS3Exception(
                     "Failed to upload " + srcPath + " to " + dstKey, OcflS3Util.unwrapCompletionEx(e)));
@@ -77,7 +77,7 @@ public class UploadFuture implements Future<CloudObjectKey> {
     public CloudObjectKey get(long timeout, TimeUnit unit)
             throws InterruptedException, ExecutionException, TimeoutException {
         try {
-            upload.completionFuture().get(timeout, unit);
+            upload.get(timeout, unit);
         } catch (RuntimeException e) {
             throw new ExecutionException(new OcflS3Exception(
                     "Failed to upload " + srcPath + " to " + dstKey, OcflS3Util.unwrapCompletionEx(e)));

--- a/ocfl-java-aws/src/test/java/io/ocfl/aws/OcflS3ClientTest.java
+++ b/ocfl-java-aws/src/test/java/io/ocfl/aws/OcflS3ClientTest.java
@@ -102,16 +102,14 @@ public class OcflS3ClientTest {
                             .buildWithDefaults(AttributeMap.builder()
                                     .put(TRUST_ALL_CERTIFICATES, Boolean.TRUE)
                                     .build()))
-                    .credentialsProvider(
-                            StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
+                    .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("foo", "bar")))
                     .build();
             tmClient = S3AsyncClient.crtBuilder()
                     .endpointOverride(URI.create(S3_MOCK.getServiceEndpoint()))
                     .region(Region.US_EAST_2)
                     .forcePathStyle(true)
                     .httpConfiguration(b -> b.trustAllCertificatesEnabled(true))
-                    .credentialsProvider(
-                            StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
+                    .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("foo", "bar")))
                     .build();
             transferManager = S3TransferManager.builder().s3Client(tmClient).build();
 

--- a/ocfl-java-aws/src/test/java/io/ocfl/aws/OcflS3Test.java
+++ b/ocfl-java-aws/src/test/java/io/ocfl/aws/OcflS3Test.java
@@ -107,16 +107,14 @@ public class OcflS3Test {
                             .buildWithDefaults(AttributeMap.builder()
                                     .put(TRUST_ALL_CERTIFICATES, Boolean.TRUE)
                                     .build()))
-                    .credentialsProvider(
-                            StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
+                    .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("foo", "bar")))
                     .build();
             tmClient = S3AsyncClient.crtBuilder()
                     .endpointOverride(URI.create(S3_MOCK.getServiceEndpoint()))
                     .region(Region.US_EAST_2)
                     .forcePathStyle(true)
                     .httpConfiguration(b -> b.trustAllCertificatesEnabled(true))
-                    .credentialsProvider(
-                            StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
+                    .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("foo", "bar")))
                     .build();
             transferManager = S3TransferManager.builder().s3Client(tmClient).build();
 

--- a/ocfl-java-itest/src/test/java/io/ocfl/itest/s3/S3BadReposITest.java
+++ b/ocfl-java-itest/src/test/java/io/ocfl/itest/s3/S3BadReposITest.java
@@ -36,6 +36,7 @@ public class S3BadReposITest extends BadReposITest {
     public static S3MockExtension S3_MOCK = S3MockExtension.builder().silent().build();
 
     private static S3AsyncClient s3Client;
+    private static S3AsyncClient tmClient;
     private static S3TransferManager transferManager;
     private static String bucket;
 
@@ -53,18 +54,22 @@ public class S3BadReposITest extends BadReposITest {
         if (StringUtils.isNotBlank(accessKey) && StringUtils.isNotBlank(secretKey) && StringUtils.isNotBlank(bucket)) {
             LOG.warn("Running tests against AWS");
             s3Client = S3ITestHelper.createS3Client(accessKey, secretKey);
+            var tm = S3ITestHelper.createTransferManager(accessKey, secretKey);
+            tmClient = tm.getLeft();
+            transferManager = tm.getRight();
             S3BadReposITest.bucket = bucket;
         } else {
             LOG.warn("Running tests against S3 Mock");
             s3Client = S3ITestHelper.createMockS3Client(S3_MOCK.getServiceEndpoint());
+            var tm = S3ITestHelper.createMockTransferManager(S3_MOCK.getServiceEndpoint());
+            tmClient = tm.getLeft();
+            transferManager = tm.getRight();
             S3BadReposITest.bucket = UUID.randomUUID().toString();
             s3Client.createBucket(request -> {
                         request.bucket(S3BadReposITest.bucket);
                     })
                     .join();
         }
-
-        transferManager = S3TransferManager.builder().s3Client(s3Client).build();
 
         dataSource = new ComboPooledDataSource();
         dataSource.setJdbcUrl(System.getProperty("db.url", "jdbc:h2:mem:test"));
@@ -76,6 +81,7 @@ public class S3BadReposITest extends BadReposITest {
     public static void afterAll() {
         s3Client.close();
         transferManager.close();
+        tmClient.close();
     }
 
     @Override

--- a/ocfl-java-itest/src/test/java/io/ocfl/itest/s3/S3ITestHelper.java
+++ b/ocfl-java-itest/src/test/java/io/ocfl/itest/s3/S3ITestHelper.java
@@ -12,9 +12,11 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Assertions;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -23,11 +25,10 @@ import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Configuration;
-import software.amazon.awssdk.services.s3.internal.multipart.MultipartS3AsyncClient;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.S3Object;
-import software.amazon.awssdk.services.s3.multipart.MultipartConfiguration;
+import software.amazon.awssdk.transfer.s3.S3TransferManager;
 import software.amazon.awssdk.utils.AttributeMap;
 
 public class S3ITestHelper {
@@ -41,41 +42,48 @@ public class S3ITestHelper {
     }
 
     public static S3AsyncClient createS3Client(String accessKey, String secretKey) {
-        return S3AsyncClient.crtBuilder()
+        return S3AsyncClient.builder()
                 .region(Region.US_EAST_2)
                 .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
+                .httpClientBuilder(NettyNioAsyncHttpClient.builder()
+                        .connectionAcquisitionTimeout(Duration.ofSeconds(60))
+                        .writeTimeout(Duration.ofSeconds(120))
+                        .readTimeout(Duration.ofSeconds(60))
+                        .maxConcurrency(100))
                 .build();
     }
 
     public static S3AsyncClient createMockS3Client(String endpoint) {
-        return MultipartS3AsyncClient.create(
-                S3AsyncClient.builder()
-                        .endpointOverride(URI.create(endpoint))
-                        .region(Region.US_EAST_2)
-                        .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("foo", "bar")))
-                        .serviceConfiguration(S3Configuration.builder()
-                                .pathStyleAccessEnabled(true)
-                                .build())
-                        .httpClient(NettyNioAsyncHttpClient.builder()
-                                .buildWithDefaults(AttributeMap.builder()
-                                        .put(TRUST_ALL_CERTIFICATES, Boolean.TRUE)
-                                        .build()))
-                        .build(),
-                MultipartConfiguration.builder().build());
+        return S3AsyncClient.builder()
+                .endpointOverride(URI.create(endpoint))
+                .region(Region.US_EAST_2)
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("foo", "bar")))
+                .serviceConfiguration(
+                        S3Configuration.builder().pathStyleAccessEnabled(true).build())
+                .httpClient(NettyNioAsyncHttpClient.builder()
+                        .buildWithDefaults(AttributeMap.builder()
+                                .put(TRUST_ALL_CERTIFICATES, Boolean.TRUE)
+                                .build()))
+                .build();
     }
 
-    /**
-     * This nonsense is needed if you're using the MultipartS3AsyncClient client and want to download a file
-     *
-     * @param client
-     * @return
-     */
-    public static S3AsyncClient resolveClient(S3AsyncClient client) {
-        if (client instanceof MultipartS3AsyncClient) {
-            return (S3AsyncClient) ((MultipartS3AsyncClient) client).delegate();
-        } else {
-            return client;
-        }
+    public static Pair<S3AsyncClient, S3TransferManager> createTransferManager(String accessKey, String secretKey) {
+        var tmClient = S3AsyncClient.crtBuilder()
+                .region(Region.US_EAST_2)
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
+                .build();
+        return Pair.of(tmClient, S3TransferManager.builder().s3Client(tmClient).build());
+    }
+
+    public static Pair<S3AsyncClient, S3TransferManager> createMockTransferManager(String endpoint) {
+        var tmClient = S3AsyncClient.crtBuilder()
+                .endpointOverride(URI.create(endpoint))
+                .region(Region.US_EAST_2)
+                .forcePathStyle(true)
+                .httpConfiguration(b -> b.trustAllCertificatesEnabled(true))
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("foo", "bar")))
+                .build();
+        return Pair.of(tmClient, S3TransferManager.builder().s3Client(tmClient).build());
     }
 
     public void verifyRepo(Path expected, String bucket, String prefix) {
@@ -117,8 +125,7 @@ public class S3ITestHelper {
     }
 
     private byte[] getObjectContent(String bucket, String prefix, String key) {
-        return resolveClient(s3Client)
-                .getObject(
+        return s3Client.getObject(
                         GetObjectRequest.builder()
                                 .bucket(bucket)
                                 .key(prefix + "/" + key)

--- a/ocfl-java-itest/src/test/java/io/ocfl/itest/s3/S3OcflITest.java
+++ b/ocfl-java-itest/src/test/java/io/ocfl/itest/s3/S3OcflITest.java
@@ -69,6 +69,7 @@ public class S3OcflITest extends OcflITest {
     public static S3MockExtension S3_MOCK = S3MockExtension.builder().silent().build();
 
     private static S3AsyncClient s3Client;
+    private static S3AsyncClient tmClient;
     private static S3TransferManager transferManager;
     private static String bucket;
 
@@ -86,18 +87,22 @@ public class S3OcflITest extends OcflITest {
         if (StringUtils.isNotBlank(accessKey) && StringUtils.isNotBlank(secretKey) && StringUtils.isNotBlank(bucket)) {
             LOG.warn("Running tests against AWS");
             s3Client = S3ITestHelper.createS3Client(accessKey, secretKey);
+            var tm = S3ITestHelper.createTransferManager(accessKey, secretKey);
+            tmClient = tm.getLeft();
+            transferManager = tm.getRight();
             S3OcflITest.bucket = bucket;
         } else {
             LOG.warn("Running tests against S3 Mock");
             s3Client = S3ITestHelper.createMockS3Client(S3_MOCK.getServiceEndpoint());
+            var tm = S3ITestHelper.createMockTransferManager(S3_MOCK.getServiceEndpoint());
+            tmClient = tm.getLeft();
+            transferManager = tm.getRight();
             S3OcflITest.bucket = UUID.randomUUID().toString();
             s3Client.createBucket(request -> {
                         request.bucket(S3OcflITest.bucket);
                     })
                     .join();
         }
-
-        transferManager = S3TransferManager.builder().s3Client(s3Client).build();
 
         dataSource = new ComboPooledDataSource();
         dataSource.setJdbcUrl(System.getProperty("db.url", "jdbc:h2:mem:test"));
@@ -109,6 +114,7 @@ public class S3OcflITest extends OcflITest {
     public static void afterAll() {
         s3Client.close();
         transferManager.close();
+        tmClient.close();
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -340,14 +340,14 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.25.13</version>
+                <version>2.25.27</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>software.amazon.awssdk.crt</groupId>
                 <artifactId>aws-crt</artifactId>
-                <version>0.29.12</version>
+                <version>0.29.14</version>
             </dependency>
 
             <!-- Test -->


### PR DESCRIPTION
It turns out the CRT client only performs well on large files. So, we should only use it with the transfer manager and only use the transfer manager for files larger than 8 MB.