### PR TITLE
size digest algorithm

### DIFF
--- a/ocfl-java-api/src/main/java/io/ocfl/api/DigestAlgorithmRegistry.java
+++ b/ocfl-java-api/src/main/java/io/ocfl/api/DigestAlgorithmRegistry.java
@@ -44,7 +44,8 @@ public final class DigestAlgorithmRegistry {
             DigestAlgorithm.blake2b160.getOcflName(), DigestAlgorithm.blake2b160,
             DigestAlgorithm.blake2b256.getOcflName(), DigestAlgorithm.blake2b256,
             DigestAlgorithm.blake2b384.getOcflName(), DigestAlgorithm.blake2b384,
-            DigestAlgorithm.sha512_256.getOcflName(), DigestAlgorithm.sha512_256));
+            DigestAlgorithm.sha512_256.getOcflName(), DigestAlgorithm.sha512_256,
+            DigestAlgorithm.size.getOcflName(), DigestAlgorithm.size));
 
     private DigestAlgorithmRegistry() {}
 

--- a/ocfl-java-api/src/main/java/io/ocfl/api/model/DigestAlgorithm.java
+++ b/ocfl-java-api/src/main/java/io/ocfl/api/model/DigestAlgorithm.java
@@ -27,11 +27,13 @@ package io.ocfl.api.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.ocfl.api.DigestAlgorithmRegistry;
+import io.ocfl.api.exception.OcflInputException;
 import io.ocfl.api.exception.OcflJavaException;
 import io.ocfl.api.util.Enforce;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 /**
  * Maps OCFL defined digest algorithms to their Java names. Java does not include built-in implementations for all of the
@@ -50,15 +52,23 @@ public class DigestAlgorithm {
     public static final DigestAlgorithm blake2b512 = new DigestAlgorithm("blake2b-512", "blake2b-512");
 
     /*
-     * From extensions: https://ocfl.github.io/extensions/0001-digest-algorithms
+     * From extensions: https://ocfl.github.io/extensions/0009-digest-algorithms
      */
     public static final DigestAlgorithm blake2b160 = new DigestAlgorithm("blake2b-160", "blake2b-160");
     public static final DigestAlgorithm blake2b256 = new DigestAlgorithm("blake2b-256", "blake2b-256");
     public static final DigestAlgorithm blake2b384 = new DigestAlgorithm("blake2b-384", "blake2b-384");
     public static final DigestAlgorithm sha512_256 = new DigestAlgorithm("sha512/256", "sha-512/256");
+    public static final DigestAlgorithm size = new DigestAlgorithm("size", new Supplier<SizeMessageDigest>() {
+        @Override
+        public SizeMessageDigest get() {
+            return new SizeMessageDigest();
+        }
+    });
 
     private final String ocflName;
     private final String javaStandardName;
+
+    private final Supplier<? extends MessageDigest> messageDigestSupplier;
 
     /**
      * Creates a DigestAlgorithm for the given OCFL name. If the name is not mapped in the {@link DigestAlgorithmRegistry}
@@ -72,7 +82,13 @@ public class DigestAlgorithm {
     public static DigestAlgorithm fromOcflName(String ocflName) {
         var algorithm = DigestAlgorithmRegistry.getAlgorithm(ocflName);
         if (algorithm == null) {
-            algorithm = new DigestAlgorithm(ocflName, null);
+            //return a supplier that throws an OcflInputException
+            algorithm = new DigestAlgorithm(ocflName, new Supplier<MessageDigest>() {
+                @Override
+                public MessageDigest get() {
+                   throw new OcflInputException("specified digest algorithm is not supported");
+                }
+            });
         }
         return algorithm;
     }
@@ -93,9 +109,42 @@ public class DigestAlgorithm {
         return algorithm;
     }
 
-    private DigestAlgorithm(String ocflName, String javaStandardName) {
+    /**
+     * Creates a DigestAlgorithm for the given OCFL name. If the name is not mapped in the {@link DigestAlgorithmRegistry}
+     * then a new object is created, but not automatically added to the registry.
+     *
+     * @param ocflName ocfl name of algorithm
+     * @param messageDigestSupplier a supplier that provides a new MessageDigest instance
+     * @return digest algorithm
+     */
+    public static DigestAlgorithm fromOcflName(String ocflName,
+        Supplier<? extends MessageDigest> messageDigestSupplier) {
+        var algorithm = DigestAlgorithmRegistry.getAlgorithm(ocflName);
+        if (algorithm == null) {
+            algorithm = new DigestAlgorithm(ocflName, messageDigestSupplier);
+        }
+        return algorithm;
+    }
+
+    protected DigestAlgorithm(String ocflName, String javaStandardName) {
         this.ocflName = Enforce.notBlank(ocflName, "ocflName cannot be blank").toLowerCase();
         this.javaStandardName = javaStandardName;
+        this.messageDigestSupplier = new Supplier<MessageDigest>() {
+            @Override
+            public MessageDigest get() {
+                try {
+                    return MessageDigest.getInstance(javaStandardName);
+                } catch (NoSuchAlgorithmException e) {
+                    throw new OcflJavaException("Failed to create message digest for: " + this, e);
+                }
+            }
+        };
+    }
+
+    protected DigestAlgorithm(String ocflName, Supplier<? extends MessageDigest> messageDigestSupplier) {
+        this.ocflName = Enforce.notBlank(ocflName, "ocflName cannot be blank").toLowerCase();
+        this.javaStandardName = "";
+        this.messageDigestSupplier = messageDigestSupplier;
     }
 
     /**
@@ -132,18 +181,14 @@ public class DigestAlgorithm {
      * @return MessageDigest
      */
     public MessageDigest getMessageDigest() {
-        try {
-            return MessageDigest.getInstance(javaStandardName);
-        } catch (NoSuchAlgorithmException e) {
-            throw new OcflJavaException("Failed to create message digest for: " + this, e);
-        }
+        return messageDigestSupplier.get();
     }
 
     @Override
     public String toString() {
         return "DigestAlgorithm{" + "ocflName='"
-                + ocflName + '\'' + ", javaStandardName='"
-                + javaStandardName + '\'' + '}';
+            + ocflName + '\'' + ", javaStandardName='"
+            + getJavaStandardName() + '\'' + '}';
     }
 
     @Override

--- a/ocfl-java-api/src/main/java/io/ocfl/api/model/SizeMessageDigest.java
+++ b/ocfl-java-api/src/main/java/io/ocfl/api/model/SizeMessageDigest.java
@@ -1,0 +1,108 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 OCFL Java Implementers Group
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.ocfl.api.model;
+
+import java.security.MessageDigest;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+* Defines a digest algorithms which calculates the size (byte count) for the input
+* and returns it as integer represented as string as specified in
+* OCFL community extension 9: https://ocfl.github.io/extensions/0009-digest-algorithms
+*/
+public class SizeMessageDigest extends MessageDigest {
+
+    public SizeMessageDigest() {
+        super("size");
+    }
+
+    AtomicLong size = new AtomicLong(0);
+
+    @Override
+    protected void engineUpdate(byte input) {
+        size.incrementAndGet();
+    }
+
+    @Override
+    protected void engineUpdate(byte[] input, int offset, int len) {
+        size.addAndGet(len);
+    }
+
+    @Override
+    protected byte[] engineDigest() {
+        return SizeMessageDigest.formatDigestAsByteArray(size.get());
+    }
+
+    @Override
+    protected void engineReset() {
+        size.set(0);
+    }
+
+    /** 
+     * convert byte array of message digest into a hex compatible String
+     * add leading zero to ensure that the length of string is even 
+     * 
+     * @param digest as byte[]
+     * @return the String containing the decimal value of the size
+     */
+    public static String formatDigest(byte[] digest) {
+        //Java17: String sizeResult = java.util.HexFormat.of().formatHex(digest);
+        StringBuilder result = new StringBuilder();
+        for (byte aByte : digest) {
+            result.append(String.format("%02x", aByte));
+        }
+        return result.length() % 2 == 0 ? result.toString() : "0" + result.toString();
+    }
+
+    /** 
+     * convert the digest value into a hex compatible String
+     * add leading zero to ensure that the length of string is even 
+     * 
+     * @param size as long value
+     * @return the String containing the decimal value of the size
+     */
+    public static String formatDigest(long size) {
+        String sizeResult = Long.toString(size);
+        return sizeResult.length() % 2 == 0 ? sizeResult : "0" + sizeResult;
+    }
+
+    /** 
+     * convert the digest value into a byte array
+     * 
+     * @param size as long value
+     * @return the byte array representing the size 
+     *         as a string representation of the integer in decimal notation
+     */
+    public static byte[] formatDigestAsByteArray(long size) {
+        String s = formatDigest(size);
+        byte[] result = new byte[s.length() / 2];
+        for (int i = 0; i < result.length; i++) {
+            int index = i * 2;
+            int val = Integer.parseInt(s.substring(index, index + 2), 16);
+            result[i] = (byte) val;
+        }
+        return result;
+    }
+
+}

--- a/ocfl-java-itest/src/test/java/io/ocfl/itest/OcflITest.java
+++ b/ocfl-java-itest/src/test/java/io/ocfl/itest/OcflITest.java
@@ -630,7 +630,7 @@ public abstract class OcflITest {
         var objectId = "o1";
 
         OcflAsserts.assertThrowsWithMessage(
-                OcflInputException.class, "specified digest algorithm is not mapped to a Java name", () -> {
+                OcflInputException.class, "specified digest algorithm is not supported", () -> {
                     repo.updateObject(ObjectVersionId.head(objectId), defaultVersionInfo.setMessage("1"), updater -> {
                         updater.addPath(ITestHelper.sourceObjectPath(objectId, "v1"))
                                 .addFileFixity("file1", DigestAlgorithm.fromOcflName("bogus"), "bogus");


### PR DESCRIPTION
These are the necessary modifications to store the file size as fixity in ocfl-inventory.json.

The use of the standardJavaName is now a little bit awkward because the calculation of the size as digest is no Java standard MessageDigest. Maybe this could be improved later. Currently I did not want to break the API, because I am not sure about any possible side effects
